### PR TITLE
Improve OpenWhisk runtime initialization

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -19,3 +19,4 @@
 import Config
 
 config :worker, docker_host: Worker.Adapters.Runtime.OpenWhisk.docker_socket()
+config :worker, max_runtime_init_retries: 20

--- a/lib/worker/adapters/runtime/openwhisk/openwhisk.ex
+++ b/lib/worker/adapters/runtime/openwhisk/openwhisk.ex
@@ -76,8 +76,8 @@ defmodule Worker.Adapters.Runtime.OpenWhisk do
   # sends function to /init endpoint of the OpenWhisk runtime
   # if the runtime refuses the connection (i.e. not ready yet), waits 0.01 seconds and retries at most max_retries times
   defp init_runtime(
-         function = %FunctionStruct{code: code},
-         runtime = %RuntimeStruct{host: host, port: port},
+         %FunctionStruct{code: code} = function,
+         %RuntimeStruct{host: host, port: port} = runtime,
          max_retries,
          retry_count \\ 0
        ) do


### PR DESCRIPTION
This PR removes the hardcoded `:timer.sleep(1000)` when initializing OpenWhisk runtimes; initialization is now attempted at most `:max_runtime_init_retries` times, specified in `runtime.exs`, with a sleep timer of 0.1 seconds between each attempt.
If the maximum number of retries is exceeded, an error is returned.

Moreover, errors during initialization are now returned even if the container creation was performed correctly.
This closes #19.