### PR TITLE
Add docker from docker

### DIFF
--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -53,6 +53,4 @@ jobs:
         with:
           context: .
           push: true
-          build-args: |
-            APP_NAME=worker
           tags: ghcr.io/funlessdev/fl-worker:latest,ghcr.io/funlessdev/fl-worker:${{ env.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,9 @@ FROM elixir:1.13.4-alpine AS builder
 
 # The following are build arguments used to change variable parts of the image.
 # The name of your application/release (required)
-ARG APP_NAME
 ARG MIX_ENV=prod
 
-ENV APP_NAME=${APP_NAME} MIX_ENV=${MIX_ENV}
+ENV MIX_ENV=${MIX_ENV}
 # RUSTUP_HOME=/opt/rust CARGO_HOME=/opt/cargo PATH=/opt/cargo/bin:$PATH
 
 # By convention, /opt is typically used for applications
@@ -50,7 +49,6 @@ RUN mix release
 # From this line onwards, we're in a new image, which will be the image used in production
 FROM alpine:${ALPINE_VERSION}
 
-ARG APP_NAME
 ARG MIX_ENV=prod
 
 # # The name of your application/release (required)
@@ -59,7 +57,6 @@ RUN apk update && \
     apk add --no-cache libstdc++ libgcc ncurses-libs socat sudo bash
 
 ENV REPLACE_OS_VARS=true \
-    APP_NAME=${APP_NAME} \
     MIX_ENV=${MIX_ENV} 
 
 WORKDIR /home/funless
@@ -68,7 +65,7 @@ RUN adduser --disabled-password --home "$(pwd)" funless &&\
 
 USER funless 
 
-COPY --chown=funless --from=builder /opt/app/_build/${MIX_ENV}/rel/${APP_NAME} ./${APP_NAME}
+COPY --chown=funless --from=builder /opt/app/_build/${MIX_ENV}/rel/worker ./worker
 
 COPY --chown=funless init_container.sh .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,14 +56,22 @@ ARG MIX_ENV=prod
 # # The name of your application/release (required)
 RUN apk update && \
     apk upgrade && \
-    apk add --no-cache libstdc++ libgcc ncurses-libs
+    apk add --no-cache libstdc++ libgcc ncurses-libs socat sudo bash
 
 ENV REPLACE_OS_VARS=true \
     APP_NAME=${APP_NAME} \
     MIX_ENV=${MIX_ENV} 
 
-WORKDIR /opt/app
+WORKDIR /home/funless
+RUN adduser --disabled-password --home "$(pwd)" funless &&\
+    echo "funless ALL=(ALL:ALL) NOPASSWD: ALL" >>/etc/sudoers
 
-COPY --from=builder /opt/app/_build/${MIX_ENV}/rel/${APP_NAME} .
+USER funless 
 
-CMD /opt/app/bin/${APP_NAME} start
+COPY --chown=funless --from=builder /opt/app/_build/${MIX_ENV}/rel/${APP_NAME} ./${APP_NAME}
+
+COPY --chown=funless init_container.sh .
+
+RUN chmod +x init_container.sh
+
+CMD ["bash", "init_container.sh"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FunlessWorker
+# Funless Worker
 
 ## Running in an interactive session
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ docker network create <NETWORK_NAME>
 
 Then, the container can be created using:
 ```
-docker create -v /var/run/docker.sock:/var/run/docker-host.sock --network=<NETWORK_NAME> <IMAGE_NAME>
+docker create -v /var/run/docker.sock:/var/run/docker-host.sock --network=<NETWORK_NAME> --env RUNTIME_NETWORK=<NETWORK_NAME> <IMAGE_NAME>
 ```
 
 Or, in a rootless installation:
 ```
-docker create -v /run/user/1001/docker.sock:/var/run/docker-host.sock --network=<NETWORK_NAME> <IMAGE_NAME>
+docker create -v /run/user/1001/docker.sock:/var/run/docker-host.sock --network=<NETWORK_NAME> --env RUNTIME_NETWORK=<NETWORK_NAME> <IMAGE_NAME>
 ```
 
 Where `/run/user/1001/docker.sock` must be set to the value of the `$DOCKER_HOST` environment variable, minus the protocol (e.g. `unix:///run/user/1001/docker.sock` -> `/run/user/1001/docker.sock`).

--- a/README.md
+++ b/README.md
@@ -50,6 +50,45 @@ The `--cookie` and `--name` parameters can vary; the `--cookie` must be the same
 
 ___
 
+## Running with Docker
+
+To run with Docker, the image can be built from source:
+```
+docker build -t <IMAGE_NAME> .
+```
+
+Afterwards, a network should be created to allow containers to communicate with each other (and therefore, to allow the Worker to communicate with runtimes):
+```
+docker network create <NETWORK_NAME>
+```
+
+Then, the container can be created using:
+```
+docker create -v /var/run/docker.sock:/var/run/docker-host.sock --network=<NETWORK_NAME> <IMAGE_NAME>
+```
+
+Or, in a rootless installation:
+```
+docker create -v /run/user/1001/docker.sock:/var/run/docker-host.sock --network=<NETWORK_NAME> <IMAGE_NAME>
+```
+
+Where `/run/user/1001/docker.sock` must be set to the value of the `$DOCKER_HOST` environment variable, minus the protocol (e.g. `unix:///run/user/1001/docker.sock` -> `/run/user/1001/docker.sock`).
+
+Finally, the container can be attached to a second network (to which the `fl-core` container is also attached):
+```
+docker network connect <SECOND_NETWORK_NAME> <CONTAINER_NAME>
+```
+
+And then started:
+```
+docker container start <CONTAINER_NAME>
+```
+
+**As of right now, <SECOND_NETWORK_NAME> must be lexicographically smaller than <NETWORK_NAME> (e.g. `cl-net` vs `fl-net`)**.
+
+(containers have to be first connected to multiple networks, and then started, as stated here https://github.com/moby/moby/issues/17750).
+___
+
 ## Code structure
 
 The code has been structured following hexagonal architecture principles; the main components are shown in the picture, divided in ports (blue circles), adapters (green circles) and core domain (inner hexagon).

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -20,3 +20,4 @@ import Config
 
 config :worker, docker_host: Worker.Adapters.Runtime.OpenWhisk.docker_socket()
 config :worker, max_runtime_init_retries: 20
+config :worker, runtime_network_name: "bridge"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -20,4 +20,4 @@ import Config
 
 config :worker, docker_host: Worker.Adapters.Runtime.OpenWhisk.docker_socket()
 config :worker, max_runtime_init_retries: 20
-config :worker, runtime_network_name: "bridge"
+config :worker, runtime_network_name: System.get_env("RUNTIME_NETWORK", "bridge")

--- a/init_container.sh
+++ b/init_container.sh
@@ -18,11 +18,15 @@
 #
 
 # The container should be run with -v /var/run/docker.sock:/var/run/docker-host.sock --network host
+# e.g. docker run --rm -v /var/run/docker.sock:/var/run/docker-host.sock --network host image-name
+
+# To specify another docker socket, use the -e DOCKER_HOST=<path>
+DOCKER_SOCK="${DOCKER_HOST:-/var/run/docker.sock}"
 
 echo "Launching worker in daemon mode"
 /home/funless/worker/bin/worker daemon
 
-echo "proxy socket is listening on /var/run/docker.sock"
-test -S /var/run/docker.sock || exec sudo /usr/bin/socat \
-  UNIX-LISTEN:/var/run/docker.sock,fork,mode=660,user=funless \
+echo "proxy socket is listening on ${DOCKER_SOCK}"
+test -S ${DOCKER_SOCK} || exec sudo /usr/bin/socat \
+  UNIX-LISTEN:${DOCKER_SOCK},fork,mode=660,user=funless \
   UNIX-CONNECT:/var/run/docker-host.sock

--- a/init_container.sh
+++ b/init_container.sh
@@ -17,11 +17,12 @@
 # under the License.
 #
 
-# The container should be run with -v /var/run/docker.sock:/var/run/docker-host.sock --network host
-# e.g. docker run --rm -v /var/run/docker.sock:/var/run/docker-host.sock --network host image-name
+# The container should be run with -v <DOCKER_HOST>:/var/run/docker-host.sock --network host
+# e.g. 
+# docker run --rm -v /run/user/1001/docker.sock:/var/run/docker-host.sock --network host image-name
+# docker run --rm -v /var/run/docker.sock:/var/run/docker-host.sock --network host image-name
 
-# To specify another docker socket, use the -e DOCKER_HOST=<path>
-DOCKER_SOCK="${DOCKER_HOST:-/var/run/docker.sock}"
+DOCKER_SOCK="/var/run/docker.sock"
 
 echo "Launching worker in daemon mode"
 /home/funless/worker/bin/worker daemon

--- a/init_container.sh
+++ b/init_container.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# The container should be run with -v /var/run/docker.sock:/var/run/docker-host.sock --network host
+
+echo "Launching worker in daemon mode"
+/home/funless/worker/bin/worker daemon
+
+echo "proxy socket is listening on /var/run/docker.sock"
+test -S /var/run/docker.sock || exec sudo /usr/bin/socat \
+  UNIX-LISTEN:/var/run/docker.sock,fork,mode=660,user=funless \
+  UNIX-CONNECT:/var/run/docker-host.sock

--- a/init_container.sh
+++ b/init_container.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 
 # The container should be run with -v /var/run/docker.sock:/var/run/docker-host.sock --network host
 

--- a/lib/worker/adapters/runtime/openwhisk/nif.ex
+++ b/lib/worker/adapters/runtime/openwhisk/nif.ex
@@ -25,9 +25,10 @@ defmodule Worker.Adapters.Runtime.OpenWhisk.Nif do
   #   ## Parameters
   #     - _function: Worker.Domain.Function struct, containing function information
   #     - _runtime_name: name of the container that will be created
+  #     - _network_name: name of the network to which the container will be attached
   #     - _docker_host: path of the docker socket in the current system
   @doc false
-  def prepare_runtime(_function, _runtime_name, _docker_host) do
+  def prepare_runtime(_function, _runtime_name, _network_name, _docker_host) do
     :erlang.nif_error(:nif_not_loaded)
   end
 

--- a/lib/worker/adapters/runtime/openwhisk/openwhisk.ex
+++ b/lib/worker/adapters/runtime/openwhisk/openwhisk.ex
@@ -56,10 +56,11 @@ defmodule Worker.Adapters.Runtime.OpenWhisk do
   def prepare(%FunctionStruct{} = function, runtime_name) do
     {:ok, socket} = Application.fetch_env(:worker, :docker_host)
     {:ok, max_retries} = Application.fetch_env(:worker, :max_runtime_init_retries)
+    {:ok, network_name} = Application.fetch_env(:worker, :runtime_network_name)
 
     Logger.info("OpenWhisk Runtime: Creating runtime for function '#{function.name}'")
 
-    Nif.prepare_runtime(function, runtime_name, socket)
+    Nif.prepare_runtime(function, runtime_name, network_name, socket)
 
     receive do
       {:ok, runtime = %RuntimeStruct{}} ->

--- a/lib/worker/adapters/runtime/openwhisk/openwhisk.ex
+++ b/lib/worker/adapters/runtime/openwhisk/openwhisk.ex
@@ -75,35 +75,46 @@ defmodule Worker.Adapters.Runtime.OpenWhisk do
 
   # sends function to /init endpoint of the OpenWhisk runtime
   # if the runtime refuses the connection (i.e. not ready yet), waits 0.01 seconds and retries at most max_retries times
-  defp init_runtime(
-         %FunctionStruct{code: code} = function,
-         %RuntimeStruct{host: host, port: port} = runtime,
-         max_retries,
-         retry_count \\ 0
-       ) do
-    if retry_count >= max_retries do
-      {:error, :max_runtime_init_retries_reached}
-    else
-      body =
-        Jason.encode!(%{
-          "value" => %{"code" => code, "main" => "main", "env" => %{}, "binary" => false}
-        })
+  defp init_runtime(_function, _runtime, 0 = _retries_left) do
+    Logger.error("OpenWhisk Runtime: runtime initialization failed.")
+    {:error, :max_runtime_init_retries_reached}
+  end
 
-      request = {"http://#{host}:#{port}/init", [], ["application/json"], body}
-      response = :httpc.request(:post, request, [], [])
+  defp init_runtime(function, runtime, retries_left) do
+    Logger.info("OpenWhisk Runtime: Initializing runtime for function '#{function.name}'")
 
-      case response do
-        {:ok, _} ->
-          {:ok, runtime}
+    response = send_init(runtime.host, runtime.port, function.code)
 
-        {:error, :socket_closed_remotely} ->
-          :timer.sleep(10)
-          init_runtime(function, runtime, max_retries, retry_count + 1)
-
-        {:error, err} ->
-          {:error, err}
-      end
+    case response do
+      {:ok, _} -> reply_from_init({:ok, runtime})
+      {:error, :socket_closed_remotely} -> retry_init(function, runtime, retries_left)
+      {:error, err} -> reply_from_init({:error, err})
     end
+  end
+
+  defp reply_from_init({:ok, runtime}) do
+    Logger.info("OpenWhisk Runtime: Runtime #{runtime.name} initialized")
+    {:ok, runtime}
+  end
+
+  defp reply_from_init({:error, err}) do
+    Logger.error("OpenWhisk Runtime: Runtime initialization failed: #{inspect(err)}")
+
+    {:error, err}
+  end
+
+  defp retry_init(function, runtime, retries_left) do
+    Logger.warn("OpenWhisk Runtime: failed to initialize runtime, retrying...")
+    :timer.sleep(10)
+    init_runtime(function, runtime, retries_left - 1)
+  end
+
+  defp send_init(host, port, code) do
+    Logger.info("OpenWhisk Runtime: sending init request to runtime at #{host}:#{port}")
+    value = %{"code" => code, "main" => "main", "env" => %{}, "binary" => false}
+    body = Jason.encode!(%{"value" => value})
+    request = {"http://#{host}:#{port}/init", [], ["application/json"], body}
+    :httpc.request(:post, request, [], [])
   end
 
   @doc """

--- a/lib/worker/domain/api/prepare.ex
+++ b/lib/worker/domain/api/prepare.ex
@@ -57,7 +57,7 @@ defmodule Worker.Domain.Api.Prepare do
   end
 
   defp store_prepared_runtime({:error, err}, _) do
-    Logger.error("API: Runtime preparation failed: #{err}")
+    Logger.error("API: Runtime preparation failed: #{inspect(err)}")
     {:error, err}
   end
 end

--- a/native/fn/src/nif.rs
+++ b/native/fn/src/nif.rs
@@ -25,6 +25,7 @@ use bollard::{
         StartContainerOptions,
     },
     models::HostConfig,
+    network::ConnectNetworkOptions,
 };
 use futures_util::TryFutureExt;
 use once_cell::sync::Lazy;
@@ -82,10 +83,17 @@ struct RuntimeContainer {
 /// * `env` - NIF parameter, represents the calling worker
 /// * `function` - A `Function` struct holding the necessary function information
 /// * `container_name` - A string holding the name of the container being created
+/// * `network_name` - A string holding the name of the network to which the container will be attached
 /// * `docker_host` - A string holding the path to the docker socket or remote host
 ///
 #[rustler::nif]
-fn prepare_runtime(env: Env, function: Function, container_name: String, docker_host: String) {
+fn prepare_runtime(
+    env: Env,
+    function: Function,
+    container_name: String,
+    network_name: String,
+    docker_host: String,
+) {
     let pid = env.pid();
 
     thread::spawn(move || {
@@ -101,7 +109,7 @@ fn prepare_runtime(env: Env, function: Function, container_name: String, docker_
         });
 
         let host_config = HostConfig {
-            publish_all_ports: Some(true),
+            publish_all_ports: Some(rootless),
             ..Default::default()
         };
 
@@ -116,6 +124,15 @@ fn prepare_runtime(env: Env, function: Function, container_name: String, docker_
             .and_then(|_| {
                 docker.start_container(&container_name, None::<StartContainerOptions<String>>)
             })
+            .and_then(|_| {
+                docker.connect_network(
+                    &network_name,
+                    ConnectNetworkOptions {
+                        container: container_name.clone(),
+                        ..Default::default()
+                    },
+                )
+            })
             .and_then(|_| docker.inspect_container(&container_name, None));
 
         let result = TOKIO.block_on(f);
@@ -125,7 +142,7 @@ fn prepare_runtime(env: Env, function: Function, container_name: String, docker_
                 let h = if rootless {
                     utils::extract_rootless_host_port(r.network_settings)
                 } else {
-                    utils::extract_host_port(r.network_settings)
+                    utils::extract_host_port(r.network_settings, network_name)
                 };
                 match h {
                     Some((host, port)) => thread_env.send_and_clear(&pid, |env| {

--- a/native/fn/src/utils.rs
+++ b/native/fn/src/utils.rs
@@ -59,7 +59,7 @@ pub fn select_image(image_name: &str) -> Option<&str> {
 ///
 /// Returns an `Error` if something goes wrong while checking or downloading the image (e.g. an invalid image name is given).
 ///
-/// Returns `Ok(())` if the image is downloaded correctly, or was already available.
+/// Returns `Ok(v)` if the image is downloaded correctly, or was already available, where `v` is the collected output stream as a Vec<CreateImageInfo>.
 ///
 /// # Arguments
 ///
@@ -110,10 +110,13 @@ pub async fn container_logs(
 ///
 /// * `ns` - A `NetworkSettings` struct wrapped by an `Option`, holds a Docker container's network information
 ///
-pub fn extract_host_port(ns: Option<NetworkSettings>) -> Option<(String, String)> {
+pub fn extract_host_port(
+    ns: Option<NetworkSettings>,
+    network_name: String,
+) -> Option<(String, String)> {
     let network_settings = ns?;
     let networks = network_settings.networks?;
-    let bridge_network = networks.get("bridge")?;
+    let bridge_network = networks.get(&network_name)?;
     let host = bridge_network.ip_address.clone()?;
     let port = String::from("8080");
     Some((host, port))
@@ -169,7 +172,7 @@ mod tests {
         });
         assert_eq!(
             Some((String::from(ip_address), String::from("8080"))),
-            extract_host_port(ns.to_owned()),
+            extract_host_port(ns.to_owned(), String::from("bridge")),
             "extract rootful host and port"
         );
         assert_eq!(


### PR DESCRIPTION
This PR closes #37 

It adds a new user `funless` in the docker file and copies the `init_container.sh` which starts the worker in daemon mode and connects a proxy to the docker socket. This way the worker from a docker container can launch containers on the host.