### PR TITLE
Init error handling

### DIFF
--- a/lib/worker/adapters/runtime/openwhisk/openwhisk.ex
+++ b/lib/worker/adapters/runtime/openwhisk/openwhisk.ex
@@ -89,9 +89,17 @@ defmodule Worker.Adapters.Runtime.OpenWhisk do
     response = send_init(runtime.host, runtime.port, function.code)
 
     case response do
-      {:ok, _} -> reply_from_init({:ok, runtime})
-      {:error, :socket_closed_remotely} -> retry_init(function, runtime, retries_left)
-      {:error, err} -> reply_from_init({:error, err})
+      {:ok, _} ->
+        reply_from_init({:ok, runtime})
+
+      {:error, :socket_closed_remotely} ->
+        retry_init(function, runtime, retries_left)
+
+      {:error, {:failed_connect, [{:to_address, _}, {_, _, :econnrefused}]}} ->
+        retry_init(function, runtime, retries_left)
+
+      {:error, err} ->
+        reply_from_init({:error, err})
     end
   end
 

--- a/lib/worker/adapters/runtime/openwhisk/openwhisk.ex
+++ b/lib/worker/adapters/runtime/openwhisk/openwhisk.ex
@@ -78,9 +78,16 @@ defmodule Worker.Adapters.Runtime.OpenWhisk do
 
   # sends function to /init endpoint of the OpenWhisk runtime
   # if the runtime refuses the connection (i.e. not ready yet), waits 0.01 seconds and retries at most max_retries times
-  defp init_runtime(_function, _runtime, 0 = _retries_left) do
+  defp init_runtime(_function, runtime, 0 = _retries_left) do
     Logger.error("OpenWhisk: runtime initialization failed.")
-    {:error, :max_runtime_init_retries_reached}
+
+    case cleanup(runtime) do
+      {:ok, _} ->
+        {:error, :max_runtime_init_retries_reached}
+
+      {:error, cleanup_err} ->
+        {:error, {:max_runtime_init_retries_reached, {:error, cleanup_err}}}
+    end
   end
 
   defp init_runtime(function, runtime, retries_left) do
@@ -99,7 +106,10 @@ defmodule Worker.Adapters.Runtime.OpenWhisk do
         retry_init(function, runtime, retries_left)
 
       {:error, err} ->
-        reply_from_init({:error, err})
+        case cleanup(runtime) do
+          {:ok, _} -> reply_from_init({:error, err})
+          {:error, cleanup_err} -> reply_from_init({:error, {err, {:error, cleanup_err}}})
+        end
     end
   end
 

--- a/lib/worker/adapters/runtime/openwhisk/openwhisk.ex
+++ b/lib/worker/adapters/runtime/openwhisk/openwhisk.ex
@@ -184,8 +184,16 @@ defmodule Worker.Adapters.Runtime.OpenWhisk do
     Nif.cleanup_runtime(runtime.name, socket)
 
     receive do
-      :ok -> {:ok, runtime}
-      {:error, err} -> {:error, err}
+      :ok ->
+        Logger.info("Runtime #{inspect(runtime)} removed")
+        {:ok, runtime}
+
+      {:error, err} ->
+        Logger.error(
+          "OpenWhisk: Error while removing runtime #{inspect(runtime)}: #{inspect(err)}"
+        )
+
+        {:error, err}
     end
   end
 end


### PR DESCRIPTION
This PR handles different issues during runtime initialization:
- add match case for `:econnrefused`, triggering a retry (previously triggered only by `:socket_closed_remotely` errors).
- remove runtime container after a failed `/init`, avoiding orphaned runtimes untracked by ETS (close #50)