### PR TITLE
Put prod log in /tmp/funless

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -24,5 +24,5 @@ config :logger,
 
 # configuration for the {LoggerFileBackend, :info_log} backend
 config :logger, :info_log,
-  path: "fl-worker.log",
+  path: "/tmp/funless/fl-worker.log",
   level: :info


### PR DESCRIPTION
This PR changes location of the logs in /tmp/funless. It will be used from the cli to map the log file to the same folder in the host.