### PR TITLE
Remove prepare and cleanup exposed actions and prepare_runtime refactor

### DIFF
--- a/lib/worker/adapters/requests/cluster/server.ex
+++ b/lib/worker/adapters/requests/cluster/server.ex
@@ -35,13 +35,6 @@ defmodule Worker.Adapters.Requests.Cluster.Server do
   end
 
   @impl true
-  def handle_call({:prepare, function}, from, _state) do
-    Logger.info("Received prepare request for #{function.name}.")
-    spawn(Cluster, :prepare, [function, from])
-    {:noreply, nil}
-  end
-
-  @impl true
   def handle_call({:invoke, function}, from, _state) do
     Logger.info("Received invocation request for #{function.name}.")
     spawn(Cluster, :invoke, [function, %{}, from])
@@ -52,13 +45,6 @@ defmodule Worker.Adapters.Requests.Cluster.Server do
   def handle_call({:invoke, function, args}, from, _state) do
     Logger.info("Received invocation request for #{function.name} with args.")
     spawn(Cluster, :invoke, [function, args, from])
-    {:noreply, nil}
-  end
-
-  @impl true
-  def handle_call({:cleanup, function}, from, _state) do
-    Logger.info("Received cleanup request for #{function.name}.")
-    spawn(Cluster, :cleanup, [function, from])
     {:noreply, nil}
   end
 end

--- a/lib/worker/adapters/runtime/test.ex
+++ b/lib/worker/adapters/runtime/test.ex
@@ -18,7 +18,7 @@ defmodule Worker.Adapters.Runtime.Provisioner.Test do
   alias Worker.Domain.RuntimeStruct
 
   @impl true
-  def prepare(_, _) do
+  def provision(_) do
     {:ok, %RuntimeStruct{name: "test-runtime", host: "localhost", port: "8080"}}
   end
 end

--- a/lib/worker/adapters/runtime/wasm/provisioner.ex
+++ b/lib/worker/adapters/runtime/wasm/provisioner.ex
@@ -24,11 +24,11 @@ defmodule Worker.Adapters.Runtime.Wasm.Provisioner do
   require Logger
 
   @impl true
-  def prepare(%FunctionStruct{code: code} = _function, runtime_name) when code != nil do
-    {:ok, %RuntimeStruct{name: runtime_name, wasm: code}}
+  def provision(%FunctionStruct{code: nil} = _function) do
+    {:ok, %RuntimeStruct{name: "runtime_name", wasm: "code"}}
   end
 
-  def prepare(_function, _runtime_name) do
+  def provision(_function) do
     {:error, :code_not_found}
   end
 end

--- a/lib/worker/domain/invoke_function.ex
+++ b/lib/worker/domain/invoke_function.ex
@@ -64,7 +64,7 @@ defmodule Worker.Domain.InvokeFunction do
   defp run_function(:runtime_not_found, %FunctionStruct{} = function, args) do
     Logger.warn("API: no runtime found to run function #{function.name}, creating one...")
 
-    with {:ok, runtime} <- ProvisionRuntime.prepare_runtime(function) do
+    with {:ok, runtime} <- ProvisionRuntime.provision(function) do
       run_function(runtime, function, args)
     end
   end

--- a/lib/worker/domain/ports/runtime/provisioner.ex
+++ b/lib/worker/domain/ports/runtime/provisioner.ex
@@ -22,7 +22,7 @@ defmodule Worker.Domain.Ports.Runtime.Provisioner do
 
   @adapter :worker |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
-  @callback prepare(FunctionStruct.t(), String.t()) :: {:ok, RuntimeStruct.t()} | {:error, any}
+  @callback provision(FunctionStruct.t()) :: {:ok, RuntimeStruct.t()} | {:error, any}
 
   @doc """
   Provisions a runtime for the given function and namespace.
@@ -31,13 +31,12 @@ defmodule Worker.Domain.Ports.Runtime.Provisioner do
 
   ## Parameters
   - function: a struct with all the fields required by Worker.Domain.Function
-  - runtime_name: the name of the runtime to be prepared
 
   ## Returns
   - `{:ok, runtime}` if the runtime is found or created.any()
   - `{:error, :runtime_not_found} if the runtime was not in the cache and it won't attempt to create one.
   - `{:error, err}` if any error is encountered
   """
-  @spec prepare(FunctionStruct.t(), String.t()) :: {:ok, RuntimeStruct.t()} | {:error, any}
-  defdelegate prepare(fl_function, runtime_name), to: @adapter
+  @spec provision(FunctionStruct.t()) :: {:ok, RuntimeStruct.t()} | {:error, any}
+  defdelegate provision(fl_function), to: @adapter
 end

--- a/test/unit/invoke_test.exs
+++ b/test/unit/invoke_test.exs
@@ -31,7 +31,7 @@ defmodule InvokeTest do
     %{function: function}
   end
 
-  describe "Invoke requests" do
+  describe "InvokeFunction" do
     setup do
       Worker.Runner.Mock |> Mox.stub_with(Worker.Adapters.Runtime.Runner.Test)
       Worker.Provisioner.Mock |> Mox.stub_with(Worker.Adapters.Runtime.Provisioner.Test)
@@ -39,12 +39,12 @@ defmodule InvokeTest do
       :ok
     end
 
-    test "invoke should return {:ok, result map} from the called function when no error is present",
+    test "should return {:ok, result map} from the called function when no error is present",
          %{function: function} do
       assert InvokeFunction.invoke(function) == {:ok, %{"result" => "test-output"}}
     end
 
-    test "invoke should return {:error, err} when running the given function raises an error",
+    test "should return {:error, err} when running the given function raises an error",
          %{function: function} do
       Worker.Runner.Mock
       |> Mox.expect(:run_function, fn _function, _args, _runtime ->
@@ -54,22 +54,22 @@ defmodule InvokeTest do
       assert InvokeFunction.invoke(function) == {:error, "generic error"}
     end
 
-    test "invoke should call prepare when no runtime is found for the given function",
+    test "should call provision when no runtime is found for the given function",
          %{function: function} do
       Worker.RuntimeCache.Mock
       |> Mox.expect(:get, fn _, _ -> :runtime_not_found end)
 
-      Worker.Provisioner.Mock |> Mox.expect(:prepare, fn _, _ -> {:ok, %{}} end)
+      Worker.Provisioner.Mock |> Mox.expect(:provision, fn _ -> {:ok, %{}} end)
 
       assert InvokeFunction.invoke(function) == {:ok, %{"result" => "test-output"}}
     end
 
-    test "invoke_function should return {:error, err} when no runtime available and its creation fails",
+    test "should return {:error, err} when no runtime available and its creation fails",
          %{function: function} do
       Worker.RuntimeCache.Mock |> Mox.expect(:get, fn _, _ -> :runtime_not_found end)
 
       Worker.Provisioner.Mock
-      |> Mox.expect(:prepare, fn _, _ -> {:error, "creation error"} end)
+      |> Mox.expect(:provision, fn _ -> {:error, "creation error"} end)
 
       assert InvokeFunction.invoke(function) == {:error, "creation error"}
     end


### PR DESCRIPTION
This PR removes the prepare and cleanup callable actions from the cluster adapter as they are not needed as of now. 
In the future we can add them again for some optimization from the core.

The prepare_runtime function in the Provisioner is also renamed into provision. 