### PR TITLE
WebAssembly fixes

### DIFF
--- a/lib/worker/adapters/runtime/wasm/nif.ex
+++ b/lib/worker/adapters/runtime/wasm/nif.ex
@@ -16,7 +16,7 @@ defmodule Worker.Adapters.Runtime.Wasm.Nif do
   @moduledoc """
   NIFs used to interact with WebAssembly runtimes.
   """
-  use Rustler, otp_app: :worker, crate: :fn_wasm
+  use Rustler, otp_app: :worker, crate: :fn_wasm, mode: :release
 
   #   Runs the function with the given code, using the underlying WebAssembly runtime.
   #   ## Parameters

--- a/lib/worker/adapters/runtime/wasm/runner.ex
+++ b/lib/worker/adapters/runtime/wasm/runner.ex
@@ -25,8 +25,8 @@ defmodule Worker.Adapters.Runtime.Wasm.Runner do
   @impl true
   def run_function(_fl_function, args, %{wasm: wasm} = _runtime) do
     Logger.info("Wasm: Running function on WebAssembly runtime")
-
-    Nif.run_function(wasm, args)
+    string_args = Jason.encode!(args)
+    Nif.run_function(wasm, string_args)
 
     receive do
       {:ok, payload} ->


### PR DESCRIPTION
This PR fixes the crash in the `run_function` call when json args are passed as a map instead of a string; now it correctly expects a map, which is then parsed into json for the NIF.

Additionally, WebAssembly NIFs are now compiled in release mode regardless of the `MIX_ENV` value.