### PR TITLE
Deployment on kind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN mix release
 FROM alpine:${ALPINE_VERSION}
 
 ARG MIX_ENV=prod
+ARG NODE_IP=""
 
 # # The name of your application/release (required)
 RUN apk update && \
@@ -54,7 +55,9 @@ RUN apk update && \
     apk add --no-cache libstdc++ libgcc ncurses-libs socat sudo bash
 
 ENV REPLACE_OS_VARS=true \
-    MIX_ENV=${MIX_ENV} 
+    MIX_ENV=${MIX_ENV} \
+    NODE_IP=${NODE_IP}
+
 
 WORKDIR /home/funless
 RUN adduser --disabled-password --home "$(pwd)" funless &&\
@@ -64,4 +67,4 @@ USER funless
 
 COPY --chown=funless --from=builder /opt/app/_build/${MIX_ENV}/rel/worker ./worker
 
-CMD worker/bin/worker start
+CMD if [[ -z "$NODE_IP" ]] ; then worker/bin/worker start ; else RELEASE_NODE=worker@${NODE_IP} worker/bin/worker start ; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ FROM alpine:${ALPINE_VERSION}
 
 ARG MIX_ENV=prod
 ARG NODE_IP=""
+ARG DEPLOY_ENV=""
 
 # # The name of your application/release (required)
 RUN apk update && \
@@ -56,7 +57,8 @@ RUN apk update && \
 
 ENV REPLACE_OS_VARS=true \
     MIX_ENV=${MIX_ENV} \
-    NODE_IP=${NODE_IP}
+    NODE_IP=${NODE_IP} \
+    DEPLOY_ENV=${DEPLOY_ENV}
 
 
 WORKDIR /home/funless
@@ -67,4 +69,7 @@ USER funless
 
 COPY --chown=funless --from=builder /opt/app/_build/${MIX_ENV}/rel/worker ./worker
 
-CMD if [[ -z "$NODE_IP" ]] ; then worker/bin/worker start ; else RELEASE_NODE=worker@${NODE_IP} worker/bin/worker start ; fi
+CMD if [[ -z "$NODE_IP" ]] ; \
+    then DEPLOY_ENV=${DEPLOY_ENV} worker/bin/worker start ; \
+    else RELEASE_NODE=worker@${NODE_IP} DEPLOY_ENV=${DEPLOY_ENV} worker/bin/worker start ; \
+    fi

--- a/config/config.exs
+++ b/config/config.exs
@@ -29,14 +29,6 @@ config :logger, :console,
   format: "\n#####[$level] $time $metadata $message\n",
   metadata: [:file, :line]
 
-config :libcluster,
-  topologies: [
-    funless: [
-      # The selected clustering strategy. Required.
-      strategy: Cluster.Strategy.Gossip
-    ]
-  ]
-
 config :os_mon,
   start_cpu_sup: true,
   start_memsup: true,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -17,3 +17,34 @@ import Config
 config :worker, docker_host: Worker.Application.docker_socket()
 config :worker, max_runtime_init_retries: 20
 config :worker, runtime_network_name: System.get_env("RUNTIME_NETWORK", "bridge")
+
+case System.get_env("DEPLOY_ENV") do
+  "kubernetes" ->
+    config :libcluster,
+      topologies: [
+        funless_worker: [
+          # The selected clustering strategy. Required.
+          strategy: Cluster.Strategy.Kubernetes,
+          config: [
+            kubernetes_ip_lookup_mode: :pods,
+            # port: String.to_integer(System.get_env("FL_LIBCLUSTER_PORT") || "45892")
+            # application_name: "worker",
+            kubernetes_node_basename: "core",
+            kubernetes_selector: "app=fl-core",
+            kubernetes_namespace: "fl"
+          ]
+        ]
+      ]
+
+  _ ->
+    config :libcluster,
+      topologies: [
+        funless_worker: [
+          # The selected clustering strategy. Required.
+          strategy: Cluster.Strategy.Gossip,
+          config: [
+            port: String.to_integer(System.get_env("FL_LIBCLUSTER_PORT") || "45892")
+          ]
+        ]
+      ]
+end


### PR DESCRIPTION
This PR adds the necessary changes for the deployment of fl-core on kind (see https://github.com/funlessdev/fl-deploy/pull/4).

Specifically:
- libcluster's strategy is now a runtime property, and can be either Gossip or Kubernetes
- the node name can be changed in the dockerized fl-worker, using the `NODE_IP` environment variable