### PR TITLE
Reply with exec_error when execution crashes

### DIFF
--- a/.github/workflows/dialyzer.yml
+++ b/.github/workflows/dialyzer.yml
@@ -31,7 +31,7 @@ jobs:
         id: beam
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: 1.13
+          elixir-version: 1.14
           otp-version: 24
 
       - name: Install Dependencies

--- a/.github/workflows/lint-elixir.yml
+++ b/.github/workflows/lint-elixir.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: 1.13
+          elixir-version: 1.14
           otp-version: 24.0
 
       - name: Install Dependencies

--- a/.github/workflows/test-elixir.yml
+++ b/.github/workflows/test-elixir.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: 1.13
+          elixir-version: 1.14
           otp-version: 24.0
 
       - name: Install Dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # This should match the version of Alpine that the `elixir:1.13.4-alpine` image uses
 ARG ALPINE_VERSION=3.16
 
-FROM elixir:1.13.4-alpine AS builder
+FROM elixir:1.14-alpine AS builder
 
 # The following are build arguments used to change variable parts of the image.
 # The name of your application/release (required)

--- a/lib/worker/adapters/runtime/wasm/runner.ex
+++ b/lib/worker/adapters/runtime/wasm/runner.ex
@@ -25,9 +25,7 @@ defmodule Worker.Adapters.Runtime.Wasm.Runner do
 
   @impl true
   def run_function(%{name: name, namespace: ns}, args, %ExecutionResource{resource: module}) do
-    Logger.info(
-      "Wasm: Running #{name} of #{ns} with WebAssembly runtime with args #{inspect(args)}"
-    )
+    Logger.info("Wasm: Running #{ns}/#{name} with args #{inspect(args)}")
 
     string_args = Jason.encode!(args)
 
@@ -39,8 +37,12 @@ defmodule Worker.Adapters.Runtime.Wasm.Runner do
         Logger.info("Wasm: Function executed successfully")
         {:ok, Jason.decode!(payload)}
 
+      {:exec_error, err} ->
+        Logger.error("Wasm: Error during function execution: #{inspect(err)}")
+        {:error, {:exec_error, err}}
+
       {:error, err} ->
-        Logger.error("Wasm: Error while running function: #{inspect(err)}")
+        Logger.error("Wasm: unexpected error: #{inspect(err)}")
         {:error, err}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -19,12 +19,17 @@ defmodule FunlessWorker.MixProject do
     [
       app: :worker,
       version: "0.4.0",
-      elixir: "~> 1.13",
+      elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       dialyzer: [
         plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
         plt_add_apps: [:ex_unit, :mix]
+      ],
+      rustler_crates: [
+        fn_wasm: [
+          mode: if(Mix.env() == :dev, do: :debug, else: :release)
+        ]
       ],
       deps: deps()
     ]

--- a/native/fn_wasm/src/nif.rs
+++ b/native/fn_wasm/src/nif.rs
@@ -44,7 +44,6 @@ fn run_function(
 
     thread::spawn(move || {
         let mut thread_env = OwnedEnv::new();
-
         let res: NifResult<(rustler::Atom, String)> =
             run_module_function(engine_resource, module_resource, args);
         match res {
@@ -90,15 +89,13 @@ fn run_module_function(
             )))
         })?;
 
-    /*
-    5. Run the function
-    if the function completed successfully, we pass the :ok atom and the content of stdout;
-    if the function's result was an error, we pass the :error atom and the content of stderr
-    */
+    // 5. Run the function
+    // if the function completed successfully, we pass the :ok atom and the content of stdout;
+    // if the function's result was an error, we pass the :error atom and the content of stderr
     let result = main_func_instance.call(&mut store, ());
     let (atom, lock) = match result {
         Ok(_) => (atoms::ok(), stdout_lock),
-        Err(_) => (atoms::error(), stderr_lock),
+        Err(_) => (atoms::exec_error(), stderr_lock),
     };
 
     // 6. Extract output


### PR DESCRIPTION
Upgrade the elixir version to 1.14 and adds a debug mode for rustler.

The worker now sends an :exec_error in case of crash during function execution.